### PR TITLE
fix: pass interface rather than string values to helm

### DIFF
--- a/pkg/apiserver/handler_system.go
+++ b/pkg/apiserver/handler_system.go
@@ -45,13 +45,13 @@ func (h *Handler) enableServiceSync(req *restful.Request, resp *restful.Response
 	}
 
 	vals := make(map[string]interface{})
-	vals["bfl"] = map[string]string{
+	vals["bfl"] = map[string]interface{}{
 		"username": owner,
 		"nodeName": bfl.Spec.NodeName,
 	}
 
 	// appCache hostpath to mount with apps
-	vals["userspace"] = map[string]string{
+	vals["userspace"] = map[string]interface{}{
 		"appCache": fmt.Sprintf("%s/Cache", pvPath),
 		"userData": fmt.Sprintf("%s/Home", pvPath),
 	}
@@ -105,12 +105,12 @@ func (h *Handler) enableServiceBackup(req *restful.Request, resp *restful.Respon
 	}
 
 	vals := make(map[string]interface{})
-	vals["bfl"] = map[string]string{
+	vals["bfl"] = map[string]interface{}{
 		"username": owner,
 		"nodeName": bfl.Spec.NodeName,
 	}
 
-	vals["userspace"] = map[string]string{
+	vals["userspace"] = map[string]interface{}{
 		"appCache": fmt.Sprintf("%s/Cache", pvPath),
 		"userData": fmt.Sprintf("%s/Home", pvPath),
 	}

--- a/pkg/users/userspace/v1/create.go
+++ b/pkg/users/userspace/v1/create.go
@@ -186,7 +186,7 @@ func (c *Creator) installSysApps(ctx context.Context, bflPod *corev1.Pod) error 
 
 	bflDocURL := fmt.Sprintf("//%s:%d/bfl/apidocs.json", ip, port)
 
-	vals["bfl"] = map[string]string{
+	vals["bfl"] = map[string]interface{}{
 		"username": c.user,
 		"nodeName": bflPod.Spec.NodeName,
 		"url":      bflDocURL,
@@ -210,11 +210,11 @@ func (c *Creator) installSysApps(ctx context.Context, bflPod *corev1.Pod) error 
 
 	// pvc to mount with filebrowser
 	pvPath := pv.Spec.HostPath.Path
-	vals["pvc"] = map[string]string{
+	vals["pvc"] = map[string]interface{}{
 		"userspace": pvcData.userspacePvc,
 	}
 
-	vals["userspace"] = map[string]string{
+	vals["userspace"] = map[string]interface{}{
 		"appCache": pvcData.appCacheHostPath,
 		"userData": fmt.Sprintf("%s/Home", pvPath),
 		"appData":  fmt.Sprintf("%s/Data", pvPath),
@@ -253,7 +253,7 @@ func (c *Creator) installSysApps(ctx context.Context, bflPod *corev1.Pod) error 
 	if err != nil {
 		return err
 	}
-	vals["kubesphere"] = map[string]string{
+	vals["kubesphere"] = map[string]interface{}{
 		"redis_password": string(redisSecret.Data["auth"]),
 	}
 
@@ -282,7 +282,7 @@ func (c *Creator) installLauncher(ctx context.Context, userspace string) (string
 	vals := make(map[string]interface{})
 
 	k, s := c.genAppkeyAndSecret("bfl")
-	vals["bfl"] = map[string]string{
+	vals["bfl"] = map[string]interface{}{
 		"username":  c.user,
 		"appKey":    k,
 		"appSecret": s,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

pass `map[string]string` as values to helm sdk will result in it cannot be merged with the chart's `values.yaml`, `map[string]interface{}` should be passed instead.