### PR TITLE
feat: watch for containerd config change

### DIFF
--- a/controllers/image_info_controller.go
+++ b/controllers/image_info_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"bytetrade.io/web3os/app-service/pkg/utils/registry"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"time"
 
 	appv1alpha1 "bytetrade.io/web3os/app-service/api/app.bytetrade.io/v1alpha1"
-	"bytetrade.io/web3os/app-service/pkg/images"
 	"bytetrade.io/web3os/app-service/pkg/utils"
 	imagetypes "github.com/containers/image/v5/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -274,7 +274,7 @@ func (r *AppImageInfoController) GetImageInfo(ctx context.Context, refs []string
 	imageInfos := make([]appv1alpha1.ImageInfo, 0)
 	for _, originRef := range refs {
 		name, _ := refdocker.ParseDockerRef(originRef)
-		replacedRef, _ := utils.ReplacedImageRef(images.MirrorsEndpoint, name.String(), false)
+		replacedRef, _ := utils.ReplacedImageRef(registry.GetMirrors(), name.String(), false)
 
 		manifest, err := r.GetManifest(ctx, replacedRef)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/emicklei/go-restful-openapi/v2 v2.9.1
 	github.com/emicklei/go-restful/v3 v3.10.1
 	github.com/envoyproxy/go-control-plane v0.11.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-crypt/crypt v0.2.25
 	github.com/go-logr/logr v1.4.2
 	github.com/go-openapi/spec v0.21.0
@@ -24,6 +25,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
 	github.com/json-iterator/go v1.1.12
+	github.com/nats-io/nats.go v1.36.0
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.23.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -115,7 +117,6 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-crypt/x v0.2.18 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-gorp/gorp/v3 v3.0.2 // indirect
@@ -182,7 +183,6 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nats-io/nats.go v1.36.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/opencontainers/runtime-spec v1.2.0 // indirect

--- a/pkg/apiserver/handler_webhook.go
+++ b/pkg/apiserver/handler_webhook.go
@@ -1,6 +1,7 @@
 package apiserver
 
 import (
+	"bytetrade.io/web3os/app-service/pkg/utils/registry"
 	"context"
 	"encoding/json"
 	"errors"
@@ -34,12 +35,7 @@ import (
 
 var (
 	errNilAdmissionRequest = fmt.Errorf("nil admission request")
-	mirrorsEndpoint        []string
 )
-
-func init() {
-	mirrorsEndpoint = utils.GetMirrorsEndpoint()
-}
 
 const (
 	deployment              = "Deployment"
@@ -506,7 +502,7 @@ func (h *Handler) cronWorkflowMutate(ctx context.Context, req *admissionv1.Admis
 		if err != nil {
 			continue
 		}
-		newImage, _ := utils.ReplacedImageRef(mirrorsEndpoint, ref.String(), false)
+		newImage, _ := utils.ReplacedImageRef(registry.GetMirrors(), ref.String(), false)
 		wf.Spec.WorkflowSpec.Templates[i].Container.Image = newImage
 	}
 	original := req.Object.Raw

--- a/pkg/images/puller.go
+++ b/pkg/images/puller.go
@@ -1,6 +1,7 @@
 package images
 
 import (
+	"bytetrade.io/web3os/app-service/pkg/utils/registry"
 	"context"
 	"errors"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 
 	appv1alpha1 "bytetrade.io/web3os/app-service/api/app.bytetrade.io/v1alpha1"
 	"bytetrade.io/web3os/app-service/pkg/utils"
-
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/content"
@@ -25,13 +25,9 @@ import (
 
 const maxRetries = 6
 
-var sock = "/var/run/containerd/containerd.sock"
-var MirrorsEndpoint []string
-
-func init() {
-	MirrorsEndpoint = utils.GetMirrorsEndpoint()
-	klog.Infof("mirrorsEndPoint: %v", MirrorsEndpoint)
-}
+var (
+	sock = "/var/run/containerd/containerd.sock"
+)
 
 type PullOptions struct {
 	AppName      string
@@ -72,7 +68,8 @@ func (is *imageService) PullImage(ctx context.Context, ref appv1alpha1.Ref, opts
 	}
 	ref.Name = originNamed.String()
 	// replaced image ref
-	replacedRef, plainHTTP := utils.ReplacedImageRef(MirrorsEndpoint, originNamed.String(), false)
+	currentMirrors := registry.GetMirrors()
+	replacedRef, plainHTTP := utils.ReplacedImageRef(currentMirrors, originNamed.String(), false)
 	config := newFetchConfig(plainHTTP)
 
 	ongoing := newJobs(replacedRef, originNamed.String())

--- a/pkg/utils/registry/mirror_watcher.go
+++ b/pkg/utils/registry/mirror_watcher.go
@@ -1,0 +1,136 @@
+package registry
+
+import (
+	"fmt"
+	"k8s.io/utils/strings/slices"
+	"os"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/klog/v2"
+
+	"bytetrade.io/web3os/app-service/pkg/utils"
+)
+
+const (
+	containerdConfigPath = "/etc/containerd/config.toml"
+)
+
+var (
+	instance *MirrorWatcher
+	once     sync.Once
+	initErr  error
+)
+
+func getMirrorWatcher() (*MirrorWatcher, error) {
+	once.Do(func() {
+		instance, initErr = newMirrorWatcher()
+		if initErr != nil {
+			klog.Errorf("Failed to initialize containerd mirror watcher: %v", initErr)
+		}
+	})
+	return instance, initErr
+}
+
+type MirrorWatcher struct {
+	watcher *fsnotify.Watcher
+	mu      sync.RWMutex
+	mirrors []string
+}
+
+// newMirrorWatcher creates a new config watcher
+func newMirrorWatcher() (*MirrorWatcher, error) {
+	if _, err := os.Stat(containerdConfigPath); err != nil {
+		klog.Warningf("Containerd config file %s does not exist, file watching disabled", containerdConfigPath)
+		return nil, err
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file watcher: %w", err)
+	}
+
+	w := &MirrorWatcher{
+		watcher: watcher,
+	}
+	w.loadConfig()
+
+	err = watcher.Add(containerdConfigPath)
+	if err != nil {
+		watcher.Close()
+		klog.Errorf("Failed to watch containerd config file: %v", err)
+		return nil, err
+	}
+
+	go w.watch()
+
+	return w, nil
+}
+
+func (w *MirrorWatcher) getMirrors() []string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	if w.watcher != nil {
+		return w.mirrors
+	}
+	return utils.GetMirrorsEndpoint()
+}
+
+// GetMirrors returns the current mirror endpoints, initializing the watcher if needed
+// this is the main exported function that other services should use
+func GetMirrors() []string {
+	watcher, err := getMirrorWatcher()
+	if err != nil {
+		// fallback to static config if watcher initialization fails
+		klog.Warningf("Failed to get config watcher instance, using static config: %v", err)
+		return utils.GetMirrorsEndpoint()
+	}
+	return watcher.getMirrors()
+}
+
+// loadConfig loads the containerd config and extracts mirror endpoints
+func (w *MirrorWatcher) loadConfig() {
+	endpoints := utils.GetMirrorsEndpoint()
+
+	w.mu.Lock()
+	oldEndpoints := w.mirrors
+	w.mirrors = endpoints
+	w.mu.Unlock()
+
+	if !slices.Equal(oldEndpoints, endpoints) {
+		klog.Infof("Containerd mirror endpoints changed from %v to %v", oldEndpoints, endpoints)
+	}
+}
+
+func (w *MirrorWatcher) watch() {
+	if w.watcher == nil {
+		return
+	}
+
+	defer w.watcher.Close()
+	defer func() { w.watcher = nil }()
+
+	for {
+		select {
+		case event, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+
+			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+				klog.Infof("Containerd config file changed: %s", event.Name)
+				w.loadConfig()
+			} else if event.Op&fsnotify.Remove != 0 {
+				klog.Warningf("Containerd config file removed: %s", event.Name)
+				return
+			}
+
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			klog.Errorf("Error watching containerd config: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Add a unified view of containerd's configured mirrors, with real-time config file watching and updating, to app-service and image-service