### PR TITLE
fix: remove non-existing manager metrics option

### DIFF
--- a/cmd/image-service/main.go
+++ b/cmd/image-service/main.go
@@ -40,7 +40,6 @@ func main() {
 	config := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:                 scheme,
-		MetricsBindAddress:     ":8087",
 		HealthProbeBindAddress: ":7081",
 		LeaderElection:         false,
 	})


### PR DESCRIPTION
In https://github.com/beclab/app-service/pull/302, controller-runtime has been updated to the latest version, and the metrics address option is no longer present in this version, thus need to be removed from the image-service cmd entry also.