### PR TITLE
feat: declare app's GPU consume policy in manifest

### DIFF
--- a/controllers/application_controller.go
+++ b/controllers/application_controller.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	appv1alpha1 "bytetrade.io/web3os/app-service/api/app.bytetrade.io/v1alpha1"
 	"bytetrade.io/web3os/app-service/pkg/apiserver/api"

--- a/pkg/apiserver/handler_webhook.go
+++ b/pkg/apiserver/handler_webhook.go
@@ -745,6 +745,13 @@ func makePatches(req *admissionv1.AdmissionRequest, appCfg *appcfg.ApplicationCo
 	original := req.Object.Raw
 	var patchBytes []byte
 	var tpl *corev1.PodTemplateSpec
+	var gpuPolicy string
+	if strings.TrimSpace(appCfg.RequiredGPU) != "" {
+		if p := strings.TrimSpace(appCfg.PodGPUConsumePolicy); p == "all" || p == "single" {
+			gpuPolicy = p
+		}
+	}
+
 	switch req.Kind.Kind {
 	case "Deployment":
 		var deploy *appsv1.Deployment
@@ -759,6 +766,9 @@ func makePatches(req *admissionv1.AdmissionRequest, appCfg *appcfg.ApplicationCo
 		tpl.ObjectMeta.Labels["io.bytetrade.app"] = "true"
 		tpl.ObjectMeta.Labels[constants.ApplicationNameLabel] = appCfg.AppName
 		tpl.ObjectMeta.Labels[constants.ApplicationOwnerLabel] = appCfg.OwnerName
+		if gpuPolicy != "" {
+			tpl.ObjectMeta.Labels[constants.AppPodGPUConsumePolicy] = gpuPolicy
+		}
 		current, err := json.Marshal(deploy)
 		if err != nil {
 			return []byte{}, err
@@ -781,6 +791,9 @@ func makePatches(req *admissionv1.AdmissionRequest, appCfg *appcfg.ApplicationCo
 		tpl.ObjectMeta.Labels["io.bytetrade.app"] = "true"
 		tpl.ObjectMeta.Labels[constants.ApplicationNameLabel] = appCfg.AppName
 		tpl.ObjectMeta.Labels[constants.ApplicationOwnerLabel] = appCfg.OwnerName
+		if gpuPolicy != "" {
+			tpl.ObjectMeta.Labels[constants.AppPodGPUConsumePolicy] = gpuPolicy
+		}
 		current, err := json.Marshal(sts)
 		if err != nil {
 			return []byte{}, err

--- a/pkg/appcfg/appcfg_types.go
+++ b/pkg/appcfg/appcfg_types.go
@@ -41,23 +41,24 @@ type AppConfiguration struct {
 }
 
 type AppSpec struct {
-	Namespace          string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
-	OnlyAdmin          bool          `yaml:"onlyAdmin,omitempty" json:"onlyAdmin,omitempty"`
-	VersionName        string        `yaml:"versionName" json:"versionName"`
-	FullDescription    string        `yaml:"fullDescription" json:"fullDescription"`
-	UpgradeDescription string        `yaml:"upgradeDescription" json:"upgradeDescription"`
-	PromoteImage       []string      `yaml:"promoteImage" json:"promoteImage"`
-	PromoteVideo       string        `yaml:"promoteVideo" json:"promoteVideo"`
-	SubCategory        string        `yaml:"subCategory" json:"subCategory"`
-	Developer          string        `yaml:"developer" json:"developer"`
-	RequiredMemory     string        `yaml:"requiredMemory" json:"requiredMemory"`
-	RequiredDisk       string        `yaml:"requiredDisk" json:"requiredDisk"`
-	SupportClient      SupportClient `yaml:"supportClient" json:"supportClient"`
-	RequiredGPU        string        `yaml:"requiredGpu" json:"requiredGpu"`
-	RequiredCPU        string        `yaml:"requiredCpu" json:"requiredCpu"`
-	RunAsUser          bool          `yaml:"runAsUser" json:"runAsUser"`
-	RunAsInternal      bool          `yaml:"runAsInternal" json:"runAsInternal"`
-	SubCharts          []Chart       `yaml:"subCharts" json:"subCharts"`
+	Namespace           string        `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	OnlyAdmin           bool          `yaml:"onlyAdmin,omitempty" json:"onlyAdmin,omitempty"`
+	VersionName         string        `yaml:"versionName" json:"versionName"`
+	FullDescription     string        `yaml:"fullDescription" json:"fullDescription"`
+	UpgradeDescription  string        `yaml:"upgradeDescription" json:"upgradeDescription"`
+	PromoteImage        []string      `yaml:"promoteImage" json:"promoteImage"`
+	PromoteVideo        string        `yaml:"promoteVideo" json:"promoteVideo"`
+	SubCategory         string        `yaml:"subCategory" json:"subCategory"`
+	Developer           string        `yaml:"developer" json:"developer"`
+	RequiredMemory      string        `yaml:"requiredMemory" json:"requiredMemory"`
+	RequiredDisk        string        `yaml:"requiredDisk" json:"requiredDisk"`
+	SupportClient       SupportClient `yaml:"supportClient" json:"supportClient"`
+	RequiredGPU         string        `yaml:"requiredGpu" json:"requiredGpu"`
+	RequiredCPU         string        `yaml:"requiredCpu" json:"requiredCpu"`
+	RunAsUser           bool          `yaml:"runAsUser" json:"runAsUser"`
+	RunAsInternal       bool          `yaml:"runAsInternal" json:"runAsInternal"`
+	PodGPUConsumePolicy string        `yaml:"podGpuConsumePolicy" json:"podGpuConsumePolicy"`
+	SubCharts           []Chart       `yaml:"subCharts" json:"subCharts"`
 }
 
 type SupportClient struct {

--- a/pkg/appcfg/application.go
+++ b/pkg/appcfg/application.go
@@ -83,6 +83,7 @@ type ApplicationConfig struct {
 	RunAsUser            bool
 	AllowedOutboundPorts []int
 	RequiredGPU          string
+	PodGPUConsumePolicy  string
 	Release              []string
 	ClusterRelease       []string
 	Internal             bool

--- a/pkg/appcfg/utils.go
+++ b/pkg/appcfg/utils.go
@@ -177,6 +177,7 @@ func getAppConfigFromConfigurationFile(app, chart, owner string) (*ApplicationCo
 		ApiTimeout:           cfg.Options.ApiTimeout,
 		AllowedOutboundPorts: cfg.Options.AllowedOutboundPorts,
 		RequiredGPU:          cfg.Spec.RequiredGPU,
+		PodGPUConsumePolicy:  cfg.Spec.PodGPUConsumePolicy,
 		Internal:             cfg.Spec.RunAsInternal,
 		Type:                 cfg.ConfigType,
 		Envs:                 cfg.Envs,

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -26,6 +26,7 @@ const (
 	ApplicationSourceLabel             = "applications.app.bytetrade.io/source"
 	ApplicationTailScaleKey            = "applications.app.bytetrade.io/tailscale"
 	ApplicationRequiredGPU             = "applications.app.bytetrade.io/required_gpu"
+	AppPodGPUConsumePolicy             = "gpu.bytetrade.io/app-pod-consume-policy"
 	ApplicationPolicies                = "applications.app.bytetrade.io/policies"
 	ApplicationMobileSupported         = "applications.app.bytetrade.io/mobile_supported"
 	ApplicationClusterDep              = "applications.app.bytetrade.io/need_cluster_scoped_app"

--- a/pkg/utils/app/app.go
+++ b/pkg/utils/app/app.go
@@ -849,6 +849,7 @@ func toApplicationConfig(app, chart string, cfg *appcfg.AppConfiguration) (*appc
 		RunAsUser:            cfg.Spec.RunAsUser,
 		AllowedOutboundPorts: cfg.Options.AllowedOutboundPorts,
 		RequiredGPU:          cfg.Spec.RequiredGPU,
+		PodGPUConsumePolicy:  cfg.Spec.PodGPUConsumePolicy,
 		Internal:             cfg.Spec.RunAsInternal,
 		SubCharts:            cfg.Spec.SubCharts,
 		ServiceAccountName:   cfg.Permission.ServiceAccount,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Add a new field `PodGPUConsumePolicy` in OlaresManifest.yaml of Application, and if declared, the corresponding label `gpu.bytetrade.io/app-pod-consume-policy` will be injected to the app pod's labels.